### PR TITLE
Add deletion functionality for lessons.

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_LESSON_DISPLAYED_INDEX = "The lesson index provided is invalid";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
@@ -1,14 +1,14 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.lesson.Lesson;
-
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Deletes a lesson identified using it's displayed index from the address book.

--- a/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.lesson.Lesson;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Deletes a lesson identified using it's displayed index from the address book.
+ */
+public class DeleteLessonCommand extends Command {
+
+    public static final String COMMAND_WORD = "rmlesson";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the lesson identified by the index number used in the displayed lesson list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_LESSON_SUCCESS = "Deleted Lesson: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteLessonCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Lesson> lastShownList = model.getFilteredLessonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
+        }
+
+        Lesson lessonToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteLesson(lessonToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_LESSON_SUCCESS, lessonToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteLessonCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteLessonCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteLessonCommandParser.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteLessonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new DeleteLessonCommand object

--- a/src/main/java/seedu/address/logic/parser/DeleteLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteLessonCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteLessonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new DeleteLessonCommand object
+ */
+public class DeleteLessonCommandParser implements Parser<DeleteLessonCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteLessonCommand
+     * and returns a DeleteLessonCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteLessonCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteLessonCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteLessonCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
+++ b/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.AddLessonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteLessonCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -71,6 +72,9 @@ public class TeachWhatParser {
 
         case AddLessonCommand.COMMAND_WORD:
             return new AddLessonCommandParser().parse(arguments);
+
+        case DeleteLessonCommand.COMMAND_WORD:
+            return new DeleteLessonCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/LessonBook.java
+++ b/src/main/java/seedu/address/model/LessonBook.java
@@ -89,7 +89,7 @@ public class LessonBook implements ReadOnlyLessonBook {
      * Removes {@code key} from this {@code LessonBook}.
      * {@code key} must exist in the lesson book.
      */
-    public void removeLesson(Lesson key) {
+    public void deleteLesson(Lesson key) {
         lessons.remove(key);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -113,4 +113,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredLessonList(Predicate<Lesson> predicate);
+
+    /**
+     * Deletes the given lesson.
+     * The lesson must exist in the lesson book.
+     */
+    void deleteLesson(Lesson lesson);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -143,6 +143,12 @@ public class ModelManager implements Model {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_LESSONS);
     }
 
+    @Override
+    public void deleteLesson(Lesson lesson) {
+        lessonBook.deleteLesson(lesson);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_LESSONS);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**


### PR DESCRIPTION
Add deletion command for ```LessonBook```. 
Deletion is specified by the index that is viewable by the user.

It uses the command ```rmlesson [index]```
Example Use Case:

Current lessons viewable by user, 
1. Make up lesson for George
    Geography
    Wednesday [5 January 2022]
    5:50 PM - 7:50 PM
2. Trial lesson for Jake
    Biology
    Friday [7 January 2022]
    6:00 PM - 8:00 PM
3. Make up lesson for Henry
    Physics
    Sunday [9 January 2022]
    12:50 AM - 2:55 AM

Jake has decided to cancel his trial lesson as he is busy.
Hence, the tutor decided to delete his lesson.
He uses the command ```rmlesson 2```.

Lessons viewable by user after deletion, 
1. Make up lesson for George
    Geography
    Wednesday [5 January 2022]
    5:50 PM - 7:50 PM
2. Make up lesson for Henry
    Physics
    Sunday [9 January 2022]
    12:50 AM - 2:55 AM


This PR Fixes #12 