### PR TITLE
Add conflicting lessons to exception

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -13,6 +13,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.lesson.Lesson;
+import seedu.address.model.lesson.exceptions.ConflictsWithLessonException;
 
 public class AddLessonCommand extends Command {
     public static final String COMMAND_WORD = "addlesson";
@@ -63,11 +64,12 @@ public class AddLessonCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasConflictingLesson(toAdd)) {
-            throw new CommandException(MESSAGE_CONFLICTING_LESSON);
+        try {
+            model.addLesson(toAdd);
+        } catch (ConflictsWithLessonException e) {
+            throw new CommandException(e.getMessage());
         }
 
-        model.addLesson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -10,6 +10,11 @@ import seedu.address.model.student.Student;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public abstract class Lesson {
+    private static final String PADDING = "   ";
+    private static final String NAME_DESCRIPTOR = "[NAME]: ";
+    private static final String SUBJECT_DESCRIPTOR = "[SUBJECT]: ";
+    private static final String ADDRESS_DESCRIPTOR = "[ADDRESS]: ";
+    private static final String DATETIMESLOT_DESCRIPTOR = "[AT]: ";
 
     // Identity fields
     private final LessonName name;
@@ -154,4 +159,19 @@ public abstract class Lesson {
      */
     public abstract boolean isConflictingWithLesson(Lesson otherLesson);
 
+    @Override
+    public String toString() {
+        StringBuilder lessonString = new StringBuilder();
+
+        lessonString
+                .append(NAME_DESCRIPTOR).append(getName().toString())
+                .append(System.getProperty("line.separator"))
+                .append(SUBJECT_DESCRIPTOR).append(getSubject().toString())
+                .append(System.getProperty("line.separator"))
+                .append(ADDRESS_DESCRIPTOR).append(getLessonAddress().toString())
+                .append(System.getProperty("line.separator"))
+                .append(DATETIMESLOT_DESCRIPTOR).append(getDateTimeSlot().toString());
+
+        return lessonString.toString();
+    }
 }

--- a/src/main/java/seedu/address/model/lesson/RecurringLesson.java
+++ b/src/main/java/seedu/address/model/lesson/RecurringLesson.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class RecurringLesson extends Lesson {
+    private static final String RECURRING_LESSON_DESCRIPTOR = "============== [RECURRING LESSON] ==============";
     private DayOfWeek dayOfLesson;
 
     /**
@@ -82,6 +83,12 @@ public class RecurringLesson extends Lesson {
 
     @Override
     public String toString() {
-        return this.getName().toString();
+        StringBuilder lessonString = new StringBuilder();
+
+        lessonString.append(RECURRING_LESSON_DESCRIPTOR)
+                .append(System.getProperty("line.separator"))
+                .append(super.toString());
+
+        return lessonString.toString();
     }
 }

--- a/src/main/java/seedu/address/model/lesson/TemporaryLesson.java
+++ b/src/main/java/seedu/address/model/lesson/TemporaryLesson.java
@@ -9,6 +9,7 @@ import java.util.Objects;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class TemporaryLesson extends Lesson {
+    private static final String TEMPORARY_LESSON_DESCRIPTOR = "============== [TEMPORARY LESSON] ==============";
 
     /**
      * Every field must be present and not null.
@@ -72,7 +73,12 @@ public class TemporaryLesson extends Lesson {
 
     @Override
     public String toString() {
-        // TODO: come up with string representation for a lesson
-        return this.getName().toString();
+        StringBuilder lessonString = new StringBuilder();
+
+        lessonString.append(TEMPORARY_LESSON_DESCRIPTOR)
+                .append(System.getProperty("line.separator"))
+                .append(super.toString());
+
+        return lessonString.toString();
     }
 }

--- a/src/main/java/seedu/address/model/lesson/exceptions/ConflictsWithLessonException.java
+++ b/src/main/java/seedu/address/model/lesson/exceptions/ConflictsWithLessonException.java
@@ -2,15 +2,12 @@ package seedu.address.model.lesson.exceptions;
 
 import seedu.address.model.lesson.Lesson;
 
-import java.util.List;
-
 /**
  * Signals that the operation will result in two lessons with conflicting timeslots.
  */
 public class ConflictsWithLessonException extends RuntimeException {
-    public static final String ERROR_MESSAGE_FIRST_PART = "This lesson:";
-    public static final String ERROR_MESSAGE_SECOND_PART = "clashes with the following lesson in your schedule:";
-    public static final String PADDING = "   -> ";
+    public static final String ERROR_MESSAGE = "Cannot add this lesson as it conflicts with this"
+            + " lesson in your schedule:";
 
     private final Lesson lessonToAdd;
     private final Lesson conflictingLesson;
@@ -31,13 +28,9 @@ public class ConflictsWithLessonException extends RuntimeException {
     public String getMessage() {
         StringBuilder message = new StringBuilder();
 
-        message.append(ERROR_MESSAGE_FIRST_PART)
-                .append(System.getProperty("line.separator"))
-                .append(PADDING).append(lessonToAdd.toString())
-                .append(System.getProperty("line.separator"))
-                .append(ERROR_MESSAGE_SECOND_PART)
-                .append(System.getProperty("line.separator"))
-                .append(PADDING).append(lessonToAdd.toString());
+        message.append(ERROR_MESSAGE)
+                .append(System.getProperty("line.separator")).append(System.getProperty("line.separator"))
+                .append(conflictingLesson.toString());
 
         return message.toString();
     }

--- a/src/main/java/seedu/address/model/lesson/exceptions/ConflictsWithLessonException.java
+++ b/src/main/java/seedu/address/model/lesson/exceptions/ConflictsWithLessonException.java
@@ -2,19 +2,43 @@ package seedu.address.model.lesson.exceptions;
 
 import seedu.address.model.lesson.Lesson;
 
+import java.util.List;
+
 /**
  * Signals that the operation will result in two lessons with conflicting timeslots.
  */
 public class ConflictsWithLessonException extends RuntimeException {
+    public static final String ERROR_MESSAGE_FIRST_PART = "This lesson:";
+    public static final String ERROR_MESSAGE_SECOND_PART = "clashes with the following lesson in your schedule:";
+    public static final String PADDING = "   -> ";
+
+    private final Lesson lessonToAdd;
+    private final Lesson conflictingLesson;
+
     /**
      * Creates an exception specifying which two lessons would conflict with each other.
-     * @param firstLesson
-     * @param secondLesson
+     * @param lessonToAdd
+     * @param conflictingLesson
      */
-    public ConflictsWithLessonException(Lesson firstLesson, Lesson secondLesson) {
-        super(
-                String.format("Operation would result in these two lessons having conflicting timeslots:\n   %s\n   %s",
-                firstLesson, secondLesson)
-        );
+    public ConflictsWithLessonException(Lesson lessonToAdd, Lesson conflictingLesson) {
+        super();
+
+        this.lessonToAdd = lessonToAdd;
+        this.conflictingLesson = conflictingLesson;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder message = new StringBuilder();
+
+        message.append(ERROR_MESSAGE_FIRST_PART)
+                .append(System.getProperty("line.separator"))
+                .append(PADDING).append(lessonToAdd.toString())
+                .append(System.getProperty("line.separator"))
+                .append(ERROR_MESSAGE_SECOND_PART)
+                .append(System.getProperty("line.separator"))
+                .append(PADDING).append(lessonToAdd.toString());
+
+        return message.toString();
     }
 }

--- a/src/main/java/seedu/address/model/lesson/exceptions/ContainsConflictingLessonsException.java
+++ b/src/main/java/seedu/address/model/lesson/exceptions/ContainsConflictingLessonsException.java
@@ -1,15 +1,15 @@
 package seedu.address.model.lesson.exceptions;
 
-import seedu.address.model.lesson.Lesson;
-
 import java.util.List;
+
+import seedu.address.model.lesson.Lesson;
 
 /**
  * Signals that the operation will result in two lessons with conflicting timeslots.
  */
 public class ContainsConflictingLessonsException extends RuntimeException {
     public static final String ERROR_MESSAGE = "These lessons have conflicting timeslots:";
-    public static final String PADDING = "   ";
+    public static final String PADDING = "   ->";
 
     private final List<Lesson> conflictingLessons;
 
@@ -25,12 +25,16 @@ public class ContainsConflictingLessonsException extends RuntimeException {
     @Override
     public String getMessage() {
         StringBuilder message = new StringBuilder();
-        message.append(ERROR_MESSAGE);
+        message.append(System.getProperty("line.separator"))
+                .append(System.getProperty("line.separator"))
+                .append(ERROR_MESSAGE)
+                .append(System.getProperty("line.separator"))
+                .append(System.getProperty("line.separator"));
 
         for (Lesson l : conflictingLessons) {
-            message.append(System.getProperty("line.separator"))
-                    .append(PADDING)
-                    .append(l.toString());
+            message.append(l.toString())
+                    .append(System.getProperty("line.separator"))
+                    .append(System.getProperty("line.separator"));
         }
 
         return message.toString();

--- a/src/main/java/seedu/address/model/lesson/exceptions/ContainsConflictingLessonsException.java
+++ b/src/main/java/seedu/address/model/lesson/exceptions/ContainsConflictingLessonsException.java
@@ -1,0 +1,38 @@
+package seedu.address.model.lesson.exceptions;
+
+import seedu.address.model.lesson.Lesson;
+
+import java.util.List;
+
+/**
+ * Signals that the operation will result in two lessons with conflicting timeslots.
+ */
+public class ContainsConflictingLessonsException extends RuntimeException {
+    public static final String ERROR_MESSAGE = "These lessons have conflicting timeslots:";
+    public static final String PADDING = "   ";
+
+    private final List<Lesson> conflictingLessons;
+
+    /**
+     * Creates an exception specifying which lessons in the list conflict with each other.
+     * @param conflictingLessons
+     */
+    public ContainsConflictingLessonsException(List<Lesson> conflictingLessons) {
+        super();
+        this.conflictingLessons = conflictingLessons;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder message = new StringBuilder();
+        message.append(ERROR_MESSAGE);
+
+        for (Lesson l : conflictingLessons) {
+            message.append(System.getProperty("line.separator"))
+                    .append(PADDING)
+                    .append(l.toString());
+        }
+
+        return message.toString();
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableLessonBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableLessonBook.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.LessonBook;
 import seedu.address.model.ReadOnlyLessonBook;
 import seedu.address.model.lesson.Lesson;
+import seedu.address.model.lesson.exceptions.ContainsConflictingLessonsException;
 
 /**
  * An Immutable AddressBook that is serializable to JSON format.
@@ -19,7 +20,7 @@ import seedu.address.model.lesson.Lesson;
 @JsonRootName(value = "lessonbook")
 class JsonSerializableLessonBook {
 
-    public static final String MESSAGE_CONFLICTING_LESSONS = "Lesson list contains duplicate lesson(s).";
+    public static final String MESSAGE_CONFLICTING_LESSONS = "Lesson list contains conflicting lesson(s).";
 
     private final List<JsonAdaptedLesson> lessons = new ArrayList<>();
 
@@ -48,14 +49,27 @@ class JsonSerializableLessonBook {
      */
     public LessonBook toModelType() throws IllegalValueException {
         LessonBook lessonBook = new LessonBook();
+        List<Lesson> lessonList = new ArrayList<>();
 
+        /*
         for (JsonAdaptedLesson jsonAdaptedLesson : lessons) {
-            Lesson lesson = jsonAdaptedLesson.toModelType(); //get boolean
+            Lesson lesson = jsonAdaptedLesson.toModelType();
             if (lessonBook.hasConflictingLesson(lesson)) {
                 throw new IllegalValueException(MESSAGE_CONFLICTING_LESSONS);
             }
 
             lessonBook.addLesson(lesson);
+        }
+        */
+
+        for (JsonAdaptedLesson jsonAdaptedLesson : lessons) {
+            lessonList.add(jsonAdaptedLesson.toModelType());
+        }
+
+        try {
+            lessonBook.setLessons(lessonList);
+        } catch (ContainsConflictingLessonsException e) {
+            throw new IllegalValueException(e.getMessage());
         }
 
         return lessonBook;

--- a/src/test/java/seedu/address/model/lesson/UniqueLessonListTest.java
+++ b/src/test/java/seedu/address/model/lesson/UniqueLessonListTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.lesson.exceptions.ConflictsWithLessonException;
+import seedu.address.model.lesson.exceptions.ContainsConflictingLessonsException;
 import seedu.address.testutil.TemporaryLessonBuilder;
 
 public class UniqueLessonListTest {
@@ -39,10 +40,10 @@ public class UniqueLessonListTest {
             nonConflictingLessonOne, nonConflictingLessonTwo);
 
     @Test
-    public void setLessons_settingConflictingLessons_throwsConflictsWithLessonException() {
+    public void setLessons_settingConflictingLessons_throwsContainsConflictingLessonsException() {
         UniqueLessonList l = new UniqueLessonList();
 
-        assertThrows(ConflictsWithLessonException.class, () -> l.setLessons(listWithConflictingLessons));
+        assertThrows(ContainsConflictingLessonsException.class, () -> l.setLessons(listWithConflictingLessons));
     }
 
     @Test


### PR DESCRIPTION
Currently, when a user tries to add a lesson that conflicts with another lesson in the schedule, the following message is displayed:
```
This lesson conflicts with an existing lesson in the schedule
```
This is not good as he/she is not informed of *which* lesson it conflicts with.

Additionally, when booting the app with a storage file that contains conflicting lessons, the logger shows a vague message that does not say which lessons are conflicting with one another:
```
INFO: Illegal values found in data/lessonbook.json: Lesson list contains duplicate lesson(s).
Mar 18, 2022 4:01:18 PM seedu.address.MainApp initModelManager
WARNING: Data file not in the correct format. Will be starting with an empty record.
```

This pull-request addresses this issue so that the user sees a more descriptive error-message:
```
Cannot add this lesson as it conflicts with this lesson in your schedule:

============== [RECURRING LESSON] ==============
[NAME]: Sec 2 Biology Lesson
[SUBJECT]: Biology
[ADDRESS]: Blk 11 Ang Mo Kio Street 74, #11-04
[AT]: Sunday [17 April 2022] [6:00 PM - 7:00 PM]
```

also, the logger would now show a more descriptive error-message:
```
INFO: Illegal values found in data/lessonbook.json: 

These lessons have conflicting timeslots:

============== [RECURRING LESSON] ==============
[NAME]: Sec 2 Biology Lesson
[SUBJECT]: Biology
[ADDRESS]: Blk 11 Ang Mo Kio Street 74, #11-04
[AT]: Sunday [17 April 2022] [6:00 PM - 7:00 PM]

============== [RECURRING LESSON] ==============
[NAME]: Sec 2 Biology Lesson
[SUBJECT]: Biology
[ADDRESS]: Blk 11 Ang Mo Kio Street 74, #11-04
[AT]: Sunday [17 April 2022] [6:00 PM - 7:00 PM]


Mar 18, 2022 4:05:46 PM seedu.address.MainApp initModelManager
WARNING: Data file not in the correct format. Will be starting with an empty record.
```