### PR TITLE
Add switching of tabs when new `Student` or `Lesson` is added

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.misc.InfoPanelTypes;
 import seedu.address.model.Model;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.lesson.exceptions.ConflictsWithLessonsException;
@@ -69,8 +70,8 @@ public class AddLessonCommand extends Command {
         } catch (ConflictsWithLessonsException e) {
             throw new CommandException(e.getMessage());
         }
-
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        model.setSelectedLesson(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, InfoPanelTypes.LESSON, ViewTab.LESSON);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_TAG;
 
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.misc.InfoPanelTypes;
 import seedu.address.model.Model;
 import seedu.address.model.student.Student;
 
@@ -55,7 +56,8 @@ public class AddStudentCommand extends Command {
         }
 
         model.addStudent(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        model.setSelectedStudent(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
@@ -164,7 +164,7 @@ public class AddStudentCommandTest {
 
         @Override
         public void setSelectedStudent(Student student) {
-            throw new AssertionError("This method should not be called.");
+            assertTrue(student != null);
         }
 
         @Override


### PR DESCRIPTION
Fixes #111 and #110. `addlesson` and `addstudent` command will toggle the tab of the GUI to the lessons or students tab respectively, if not already on the tab. Additionally, details of the new `Lesson` or `Student` added will also be displayed on the InfoPanel.

#### Before executing the command:
![image](https://user-images.githubusercontent.com/75308402/159650871-0f258e45-1084-46a4-b651-89db0870971a.png)

#### After executing the command:
![image](https://user-images.githubusercontent.com/75308402/159651101-49fcf9a8-4ece-4322-8144-4bdb724336ea.png)
