### PR TITLE
Remove restriction for adding past lessons

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,8 +33,6 @@ public class ParserUtil {
     public static final String INVALID_DATE_FORMAT_MESSAGE = "Invalid date format! Date must be in DD-MM-YYYY\n"
             + "[EXAMPLE]: to specify that a lesson is on 25th March 2022, include the following\n"
             + "-d 25-03-2022";
-    public static final String INVALID_DATE_PASTDATE_MESSAGE = "Retroactively creating lessons "
-            + "for past dates is not allowed!";
 
     public static final String INVALID_HOURS_FORMAT_MESSAGE = "Invalid duration in hours format! "
             + "Hours must be a non-negative integer.\n"
@@ -248,11 +246,6 @@ public class ParserUtil {
             lessonDate = LocalDate.parse(trimmedDateString, acceptedDateTimeFormat);
         } catch (DateTimeParseException exception) {
             throw new ParseException(INVALID_DATE_FORMAT_MESSAGE);
-        }
-
-        LocalDate today = LocalDate.now();
-        if (lessonDate.isBefore(today)) {
-            throw new ParseException(INVALID_DATE_PASTDATE_MESSAGE);
         }
 
         return lessonDate;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -93,8 +93,6 @@ public class CommandTestUtil {
             + PREFIX_DATE + "25 March 2022";
     public static final String INVALID_LESSON_START_TIME_FORMAT_DESC = " " // start time must be given in "HH:mm" format
             + PREFIX_START_TIME + "6pm";
-    public static final String INVALID_LESSON_DATE_PASTDATE_DESC = " " // cannot create new lessons in the past
-            + PREFIX_DATE + "1-12-2020";
 
     // hours and minutes cannot both be zero as the duration of a lesson should not be zero
     public static final String INVALID_DURATION_MINUTES_ZERO_DESC = " "

--- a/src/test/java/seedu/address/logic/parser/AddLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLessonCommandParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION_MINU
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION_MINUTES_NEGATIVE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION_MINUTES_ZERO_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LESSON_DATE_FORMAT_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LESSON_DATE_PASTDATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LESSON_START_TIME_FORMAT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LESSON_ADDRESS_DESC_AMK;
 import static seedu.address.logic.commands.CommandTestUtil.LESSON_DATE_DESC;
@@ -22,7 +21,6 @@ import static seedu.address.logic.parser.AddLessonCommandParser.INVALID_DURATION
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.INVALID_DATE_FORMAT_MESSAGE;
-import static seedu.address.logic.parser.ParserUtil.INVALID_DATE_PASTDATE_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.INVALID_START_TIME_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.MINUTES_GREATER_THAN_59_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.NEGATIVE_HOURS_MESSAGE;
@@ -105,16 +103,5 @@ public class AddLessonCommandParserTest {
                 + LESSON_DURATION_HOURS_DESC_2HOUR
                 + INVALID_DURATION_MINUTES_EXCEEDS_59_DESC,
                 MINUTES_GREATER_THAN_59_MESSAGE);
-    }
-
-    @Test
-    public void addLessonCommand_withPastDate_throwsParseException() {
-        assertParseFailure(parser, LESSON_NAME_DESC_TRIAL_LESSON + LESSON_SUBJECT_DESC_BIOLOGY
-                        + LESSON_ADDRESS_DESC_AMK
-                        + INVALID_LESSON_DATE_PASTDATE_DESC
-                        + LESSON_START_TIME_DESC_6PM
-                        + LESSON_DURATION_HOURS_DESC_2HOUR
-                        + LESSON_DURATION_MINUTES_DESC_30MIN,
-                INVALID_DATE_PASTDATE_MESSAGE);
     }
 }


### PR DESCRIPTION
Previously, adding lessons in the past was not allowed and an error would be shown to the user.

This pull-request changes the `addlesson` command to allow users to add lessons in the past for record-keeping purposes.