### PR TITLE
Implement `unassign` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT;
 
@@ -33,8 +34,7 @@ public class AssignCommand extends Command {
      * @param lessonIndex the index of the lesson that the student should be added to
      */
     public AssignCommand(Index studentIndex, Index lessonIndex) {
-        requireNonNull(studentIndex);
-        requireNonNull(lessonIndex);
+        requireAllNonNull(studentIndex, lessonIndex);
         this.studentIndex = studentIndex;
         this.lessonIndex = lessonIndex;
     }
@@ -42,10 +42,10 @@ public class AssignCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        if (model.getFilteredLessonList().size() < lessonIndex.getOneBased()) {
+        if (model.checkStudentListIndex(studentIndex)) {
             throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "lesson", lessonIndex.getOneBased()));
         }
-        if (model.getFilteredStudentList().size() < studentIndex.getOneBased()) {
+        if (model.checkLessonListIndex(lessonIndex)) {
             throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "student", studentIndex.getOneBased()));
         }
         Lesson lesson = model.getFilteredLessonList().get(lessonIndex.getZeroBased());
@@ -57,6 +57,6 @@ public class AssignCommand extends Command {
         model.updateAssignment(student, lesson);
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, student.getName(), lesson.getName()),
-                true, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
+                true, InfoPanelTypes.LESSON, ViewTab.LESSON);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.misc.InfoPanelTypes;
+import seedu.address.model.Model;
+import seedu.address.model.lesson.Lesson;
+import seedu.address.model.student.Student;
+
+public class UnassignCommand extends Command {
+    public static final String COMMAND_WORD = "unassign";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unassigns a student from a lesson \n"
+            + "Parameters: "
+            + PREFIX_STUDENT + " STUDENT_ID "
+            + PREFIX_LESSON + " LESSON_ID"
+            + "\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_STUDENT + " 5"
+            + PREFIX_LESSON + " 3";
+    public static final String MESSAGE_SUCCESS = "%1$s has been unassigned to %2$s successfully!";
+    public static final String MESSAGE_NOT_ENROLLED = "%1$s is not enrolled in %2$s!";
+    public static final String MESSAGE_NO_SUCH_ID = "There is no %1$s with an ID of %2$s!";
+    private final Index lessonId;
+    private final Index studentId;
+
+    /**
+     * Constructor for the UnassignCommand class
+     * @param studentId {@code Index} of the student to be unassigned
+     * @param lessonId {@code Index} of the lesson to be unassigned
+     */
+    public UnassignCommand(Index studentId, Index lessonId) {
+        requireAllNonNull(studentId, lessonId);
+        this.lessonId = lessonId;
+        this.studentId = studentId;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (model.checkStudentListIndex(studentId)) {
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "lesson", lessonId.getOneBased()));
+        }
+        if (model.checkLessonListIndex(lessonId)) {
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "student", studentId.getOneBased()));
+        }
+
+        Student student = model.getFilteredStudentList().get(studentId.getZeroBased());
+        Lesson lesson = model.getFilteredLessonList().get(lessonId.getZeroBased());
+        if (!student.isEnrolledIn(lesson) || !lesson.hasAlreadyAssigned(student)) {
+            throw new CommandException(String.format(MESSAGE_NOT_ENROLLED, student.getName(), lesson.getName()));
+        }
+        model.updateUnassignment(student, lesson);
+        model.setSelectedStudent(student);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, student.getName(), lesson.getName()),
+                true, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
+++ b/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListLessonsCommand;
 import seedu.address.logic.commands.ListStudentsCommand;
+import seedu.address.logic.commands.UnassignCommand;
 import seedu.address.logic.commands.ViewLessonInfoCommand;
 import seedu.address.logic.commands.ViewStudentInfoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -87,6 +88,9 @@ public class TeachWhatParser {
 
         case DeleteLessonCommand.COMMAND_WORD:
             return new DeleteLessonCommandParser().parse(arguments);
+
+        case UnassignCommand.COMMAND_WORD:
+            return new UnassignCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/UnassignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnassignCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class UnassignCommandParser implements Parser<UnassignCommand> {
+    @Override
+    public UnassignCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_STUDENT, PREFIX_LESSON);
+        if (CheckPrefixes.arePrefixesAbsent(argumentMultimap, PREFIX_STUDENT, PREFIX_LESSON)
+                || !argumentMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE));
+        }
+        try {
+            Index lessonId = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_LESSON).get());
+            Index studentId = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_STUDENT).get());
+            return new UnassignCommand(studentId, lessonId);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.student.Student;
 
@@ -127,6 +128,11 @@ public interface Model {
     void updateAssignment(Student student, Lesson lesson);
 
     /**
+     * Updates both filtered lesson and students list.
+     */
+    void updateUnassignment(Student student, Lesson lesson);
+
+    /**
      * Sets the selected {@code Student} with the given {@code Student} for UI use.
      * @param student The given {@code Student}.
      */
@@ -143,4 +149,14 @@ public interface Model {
 
     /** Returns the selected {@code Lesson} */
     Lesson getSelectedLesson();
+
+    /**
+     * Checks if the {@code Index} provided is out of bounds of the {@code filteredStudentList}
+     */
+    boolean checkStudentListIndex(Index studentId);
+
+    /**
+     * Checks if the {@code Index} provided is out of bounds of the {@code filteredLessonList}
+     */
+    boolean checkLessonListIndex(Index lessonId);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.student.Student;
 
@@ -213,13 +214,28 @@ public class ModelManager implements Model {
         filteredLessons.setPredicate(predicate);
     }
 
-    // TODO: add the remaining functions for LessonList too
     @Override
     public void updateAssignment(Student studentToAssign, Lesson lessonToAssign) {
         lessonBook.assignStudent(studentToAssign, lessonToAssign);
         studentBook.assignLesson(lessonToAssign, studentToAssign);
         updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
         updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
+    }
+
+    @Override
+    public void updateUnassignment(Student student, Lesson lesson) {
+        student.unassignLesson(lesson);
+        lesson.unassignStudent(student);
+        updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
+        updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
+    }
+
+    public boolean checkStudentListIndex(Index studentId) {
+        return filteredStudents.size() < studentId.getOneBased();
+    }
+
+    public boolean checkLessonListIndex(Index lessonId) {
+        return filteredLessons.size() < lessonId.getOneBased();
     }
 
     //=========== Selected Student and Lesson Accessors and Setter ============================================
@@ -239,4 +255,5 @@ public class ModelManager implements Model {
     public Lesson getSelectedLesson() {
         return selectedLesson;
     }
+
 }

--- a/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyLessonBook;
@@ -203,6 +204,21 @@ public class AddStudentCommandTest {
 
         @Override
         public void updateAssignment(Student student, Lesson lesson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateUnassignment(Student student, Lesson lesson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean checkLessonListIndex(Index lessonId) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean checkStudentListIndex(Index studentId) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Fixes #98. 

The command unassigns the `Student` of the given `STUDENT_ID` from the `Lesson` of the given `LESSON_ID`.
* the `Student` is removed from `enrolledStudents` of the `Lesson`
* the `Lesson` is removed from `enrolledLessons` of the `Student`