### PR TITLE
Implement `findlesson` command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_INVALID_LESSON_DISPLAYED_INDEX = "The lesson index provided is invalid.";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
+    public static final String MESSAGE_LESSONS_LISTED_OVERVIEW = "%1$d lessons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/FindLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindLessonCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.lesson.LessonNameContainsKeywordsPredicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Finds and lists all lessons in the lesson book whose name contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindLessonCommand extends Command {
+
+    public static final String COMMAND_WORD = "findlesson";
+    public static final String SHORTENED_COMMAND_WORD = "fl";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all lessons whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " makeup lesson";
+
+    private final LessonNameContainsKeywordsPredicate predicate;
+
+    public FindLessonCommand(LessonNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredLessonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_LESSONS_LISTED_OVERVIEW, model.getFilteredLessonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindLessonCommand // instanceof handles nulls
+                && predicate.equals(((FindLessonCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FindLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindLessonCommand.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.lesson.LessonNameContainsKeywordsPredicate;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Finds and lists all lessons in the lesson book whose name contains any of the argument keywords.
@@ -32,6 +32,16 @@ public class FindLessonCommand extends Command {
         model.updateFilteredLessonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_LESSONS_LISTED_OVERVIEW, model.getFilteredLessonList().size()));
+    }
+
+    /**
+     * Returns true if the command word entered inside the user-input matches any of the
+     * specified keywords identified with this command.
+     */
+    public boolean matchesCommandWord(String commandWord) {
+        String lowerCaseCommandWord = commandWord.toLowerCase();
+
+        return commandWord.equals(COMMAND_WORD) || commandWord.equals(SHORTENED_COMMAND_WORD);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FindLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindLessonCommandParser.java
@@ -1,13 +1,12 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.FindLessonCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.lesson.LessonNameContainsKeywordsPredicate;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import seedu.address.logic.commands.FindLessonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.lesson.LessonNameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindLessonCommand object

--- a/src/main/java/seedu/address/logic/parser/FindLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindLessonCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindLessonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.lesson.LessonNameContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new FindLessonCommand object
+ */
+public class FindLessonCommandParser implements Parser<FindLessonCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindLessonCommand
+     * and returns a FindLessonCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindLessonCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindLessonCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindLessonCommand(new LessonNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
+++ b/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
@@ -6,7 +6,21 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddLessonCommand;
+import seedu.address.logic.commands.AddStudentCommand;
+import seedu.address.logic.commands.AssignCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteLessonCommand;
+import seedu.address.logic.commands.DeleteStudentCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindLessonCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListLessonsCommand;
+import seedu.address.logic.commands.ListStudentsCommand;
+import seedu.address.logic.commands.ViewLessonInfoCommand;
+import seedu.address.logic.commands.ViewStudentInfoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
+++ b/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
@@ -6,20 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddLessonCommand;
-import seedu.address.logic.commands.AddStudentCommand;
-import seedu.address.logic.commands.AssignCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteLessonCommand;
-import seedu.address.logic.commands.DeleteStudentCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListLessonsCommand;
-import seedu.address.logic.commands.ListStudentsCommand;
-import seedu.address.logic.commands.ViewLessonInfoCommand;
-import seedu.address.logic.commands.ViewStudentInfoCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -60,6 +47,9 @@ public class TeachWhatParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case FindLessonCommand.COMMAND_WORD:
+            return new FindLessonCommandParser().parse(arguments);
 
         case ListStudentsCommand.COMMAND_WORD:
             return new ListStudentsCommand();

--- a/src/main/java/seedu/address/model/lesson/LessonNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/lesson/LessonNameContainsKeywordsPredicate.java
@@ -1,9 +1,9 @@
 package seedu.address.model.lesson;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Lesson}'s {@code LessonName} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/lesson/LessonNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/lesson/LessonNameContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.lesson;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Lesson}'s {@code LessonName} matches any of the keywords given.
+ */
+public class LessonNameContainsKeywordsPredicate implements Predicate<Lesson> {
+    private final List<String> keywords;
+
+    public LessonNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Lesson lesson) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(lesson.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof LessonNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((LessonNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/model/lesson/LessonNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/lesson/LessonNameContainsKeywordsPredicateTest.java
@@ -1,0 +1,84 @@
+package seedu.address.model.lesson;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.TemporaryLessonBuilder;
+
+public class LessonNameContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        LessonNameContainsKeywordsPredicate firstPredicate =
+                new LessonNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        LessonNameContainsKeywordsPredicate secondPredicate =
+                new LessonNameContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        LessonNameContainsKeywordsPredicate firstPredicateCopy =
+                new LessonNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different lesson -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        LessonNameContainsKeywordsPredicate predicate =
+                new LessonNameContainsKeywordsPredicate(Collections.singletonList("Biology"));
+        assertTrue(predicate.test(new TemporaryLessonBuilder().withName("Biology").build()));
+
+        // Multiple keywords
+        predicate = new LessonNameContainsKeywordsPredicate(Arrays.asList("Biology", "Lesson"));
+        assertTrue(predicate.test(new TemporaryLessonBuilder().withName("Biology Lesson").build()));
+
+        // Only one matching keyword
+        predicate = new LessonNameContainsKeywordsPredicate(Arrays.asList("Biology", "Lesson"));
+        assertTrue(predicate.test(new TemporaryLessonBuilder().withName("Biology Class").build()));
+
+        // Mixed-case keywords
+        predicate = new LessonNameContainsKeywordsPredicate(Arrays.asList("bIoLoGy", "lEsSoN"));
+        assertTrue(predicate.test(new TemporaryLessonBuilder().withName("Biology Lesson").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        LessonNameContainsKeywordsPredicate predicate =
+                new LessonNameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new TemporaryLessonBuilder().withName("Biology Lesson").build()));
+
+        // Non-matching keyword
+        predicate = new LessonNameContainsKeywordsPredicate(Arrays.asList("Biology"));
+        assertFalse(predicate.test(new TemporaryLessonBuilder().withName("History Lesson").build()));
+
+        // Keywords match subject and address, but does not match name
+        predicate = new LessonNameContainsKeywordsPredicate(Arrays.asList("Biology", "Toa", "Payoh"));
+        assertFalse(predicate.test(new TemporaryLessonBuilder()
+                .withName("History Lesson")
+                .withSubject("Biology")
+                .withAddress("Block 235 Toa Payoh #20-111")
+                .build())
+        );
+    }
+}


### PR DESCRIPTION
Fixes #108.

The `findlesson` command accepts one or more keywords and updates the UI with a list of lessons that is filtered as follows:
- if any of the specified keywords appears in the name of the lesson, then the lesson will be displayed in the UI
- else, it will not appear in the filtered list

### Example
1. "Biology Lesson"
2. "History Lesson"

- if the only keyword specified is "Lesson"
   - both lessons would appear
- if the only keyword specified is "History"
   - only the second lesson would appear  
- if two keywords "History" and "Lesson" are specified
   - both lessons would also appear; as "Lesson" is found in both names   