### PR TITLE
Show conflicting lessons in UI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -13,6 +13,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.misc.InfoPanelTypes;
 import seedu.address.model.Model;
+import seedu.address.model.lesson.ConflictingLessonsPredicate;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.lesson.exceptions.ConflictsWithLessonsException;
 
@@ -68,8 +69,10 @@ public class AddLessonCommand extends Command {
         try {
             model.addLesson(toAdd);
         } catch (ConflictsWithLessonsException e) {
-            throw new CommandException(e.getMessage());
+            model.updateFilteredLessonList(new ConflictingLessonsPredicate(toAdd));
+            throw new CommandException(ConflictsWithLessonsException.ERROR_MESSAGE);
         }
+
         model.setSelectedLesson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, InfoPanelTypes.LESSON, ViewTab.LESSON);
     }

--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -70,7 +70,9 @@ public class AddLessonCommand extends Command {
             model.addLesson(toAdd);
         } catch (ConflictsWithLessonsException e) {
             model.updateFilteredLessonList(new ConflictingLessonsPredicate(toAdd));
-            throw new CommandException(ConflictsWithLessonsException.ERROR_MESSAGE);
+
+            return new CommandResult(ConflictsWithLessonsException.ERROR_MESSAGE,
+                    true, InfoPanelTypes.LESSON, ViewTab.LESSON);
         }
 
         model.setSelectedLesson(toAdd);

--- a/src/main/java/seedu/address/model/lesson/ConflictingLessonsPredicate.java
+++ b/src/main/java/seedu/address/model/lesson/ConflictingLessonsPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.lesson;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Lesson} clashes with the specified {@code Lesson}.
+ */
+public class ConflictingLessonsPredicate implements Predicate<Lesson> {
+    private final Lesson lessonToCheck;
+
+    public ConflictingLessonsPredicate(Lesson lessonToCheck) {
+        this.lessonToCheck = lessonToCheck;
+    }
+
+    @Override
+    public boolean test(Lesson lesson) {
+        return lesson.isConflictingWithLesson(lessonToCheck);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ConflictingLessonsPredicate // instanceof handles nulls
+                && lessonToCheck.equals(((ConflictingLessonsPredicate) other).lessonToCheck)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/model/lesson/ConflictingLessonsPredicateTest.java
+++ b/src/test/java/seedu/address/model/lesson/ConflictingLessonsPredicateTest.java
@@ -1,0 +1,85 @@
+package seedu.address.model.lesson;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.testutil.TemporaryLessonBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ConflictingLessonsPredicateTest {
+    @Test
+    public void equals() {
+        Lesson firstLessonToCheck = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .build();
+        Lesson secondLessonToCheck = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,2,18,0), 1,0)
+                .build();
+
+        ConflictingLessonsPredicate firstPredicate = new ConflictingLessonsPredicate(firstLessonToCheck);
+        ConflictingLessonsPredicate secondPredicate = new ConflictingLessonsPredicate(secondLessonToCheck);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ConflictingLessonsPredicate firstPredicateCopy = new ConflictingLessonsPredicate(firstLessonToCheck);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different lesson -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_lessonsAreConflicting_returnsTrue() {
+        // lessons with same starting date and time
+        Lesson existingLesson = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .build();
+        Lesson lessonWithSameStartingDateTime = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .build();
+        ConflictingLessonsPredicate predicate = new ConflictingLessonsPredicate(lessonWithSameStartingDateTime);
+        assertTrue(predicate.test(existingLesson));
+
+        // lessons with overlapping time slots
+        Lesson lessonThatStartsBeforeOtherLessonEnds = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,30), 1,0)
+                .build();
+        predicate = new ConflictingLessonsPredicate(lessonThatStartsBeforeOtherLessonEnds);
+        assertTrue(predicate.test(existingLesson));
+    }
+
+    @Test
+    public void test_lessonsThatAreNotConflicting_returnsFalse() {
+        // consecutive lessons
+        Lesson existingLesson = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .build();
+        Lesson lessonThatStartsRightAfterPreviousOneEnds = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,1,19,0), 1,0)
+                .build();
+        ConflictingLessonsPredicate predicate = new ConflictingLessonsPredicate(lessonThatStartsRightAfterPreviousOneEnds);
+        assertFalse(predicate.test(existingLesson));
+
+        // lessons on different days but same time
+        Lesson lessonOnDifferentDayButSameStartTime = new TemporaryLessonBuilder()
+                .withDateTimeSlot(LocalDateTime.of(2022,1,2,18,0), 1,0)
+                .build();
+        predicate = new ConflictingLessonsPredicate(lessonOnDifferentDayButSameStartTime);
+        assertFalse(predicate.test(existingLesson));
+    }
+}

--- a/src/test/java/seedu/address/model/lesson/ConflictingLessonsPredicateTest.java
+++ b/src/test/java/seedu/address/model/lesson/ConflictingLessonsPredicateTest.java
@@ -3,24 +3,20 @@ package seedu.address.model.lesson;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.testutil.TemporaryLessonBuilder;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public class ConflictingLessonsPredicateTest {
     @Test
     public void equals() {
         Lesson firstLessonToCheck = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 1, 18, 0), 1, 0)
                 .build();
         Lesson secondLessonToCheck = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,2,18,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 2, 18, 0), 1, 0)
                 .build();
 
         ConflictingLessonsPredicate firstPredicate = new ConflictingLessonsPredicate(firstLessonToCheck);
@@ -47,17 +43,17 @@ public class ConflictingLessonsPredicateTest {
     public void test_lessonsAreConflicting_returnsTrue() {
         // lessons with same starting date and time
         Lesson existingLesson = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 1, 18, 0), 1, 0)
                 .build();
         Lesson lessonWithSameStartingDateTime = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 1, 18, 0), 1, 0)
                 .build();
         ConflictingLessonsPredicate predicate = new ConflictingLessonsPredicate(lessonWithSameStartingDateTime);
         assertTrue(predicate.test(existingLesson));
 
         // lessons with overlapping time slots
         Lesson lessonThatStartsBeforeOtherLessonEnds = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,30), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 1, 18, 30), 1, 0)
                 .build();
         predicate = new ConflictingLessonsPredicate(lessonThatStartsBeforeOtherLessonEnds);
         assertTrue(predicate.test(existingLesson));
@@ -67,17 +63,18 @@ public class ConflictingLessonsPredicateTest {
     public void test_lessonsThatAreNotConflicting_returnsFalse() {
         // consecutive lessons
         Lesson existingLesson = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,1,18,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 1, 18, 0), 1, 0)
                 .build();
         Lesson lessonThatStartsRightAfterPreviousOneEnds = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,1,19,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 1, 19, 0), 1, 0)
                 .build();
-        ConflictingLessonsPredicate predicate = new ConflictingLessonsPredicate(lessonThatStartsRightAfterPreviousOneEnds);
+        ConflictingLessonsPredicate predicate =
+                new ConflictingLessonsPredicate(lessonThatStartsRightAfterPreviousOneEnds);
         assertFalse(predicate.test(existingLesson));
 
         // lessons on different days but same time
         Lesson lessonOnDifferentDayButSameStartTime = new TemporaryLessonBuilder()
-                .withDateTimeSlot(LocalDateTime.of(2022,1,2,18,0), 1,0)
+                .withDateTimeSlot(LocalDateTime.of(2022, 1, 2, 18, 0), 1, 0)
                 .build();
         predicate = new ConflictingLessonsPredicate(lessonOnDifferentDayButSameStartTime);
         assertFalse(predicate.test(existingLesson));


### PR DESCRIPTION
Fixes #93.

Currently, when a user attempts to add a lesson that conflicts with some lesson(s) in the list, only a description of these lesson(s) would be provided in the message-box.

A user may wish to remove these conflicting lessons so that he/she may proceed to add the new lesson.

To make this easier, in such a situation, lets instead update the lesson list on the UI with a list of such conflicting lessons so that the user can run `rmlesson` to remove these lessons as needed.