### PR TITLE
Implement edit `Lesson` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -42,7 +42,7 @@ public class AddLessonCommand extends Command {
             + "\n     "
             + PREFIX_LESSON_ADDRESS + " Blk 11 Ang Mo Kio Street 74, #11-04 "
             + "\n     "
-            + PREFIX_DATE + "19-12-2022 "
+            + PREFIX_DATE + " 19-12-2022 "
             + PREFIX_START_TIME + " 18:00 "
             + PREFIX_DURATION_HOURS + " 2 "
             + PREFIX_DURATION_MINUTES + " 15 ";

--- a/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
@@ -18,7 +18,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.misc.InfoPanelTypes;

--- a/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
@@ -31,10 +31,9 @@ import seedu.address.model.lesson.Subject;
 
 public class EditLessonCommand extends Command {
     public static final String COMMAND_WORD = "editlesson";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a lesson to the schedule"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits a lesson from the list of lessons "
             + "\n"
-            + "Parameters: "
-            + PREFIX_LESSON + " LESSON_ID "
+            + "Parameters: LESSON_ID "
             + PREFIX_LESSON_NAME + " NAME "
             + PREFIX_SUBJECT + " SUBJECT "
             + PREFIX_LESSON_ADDRESS + " ADDRESS "
@@ -107,10 +106,16 @@ public class EditLessonCommand extends Command {
                 .orElse(toEdit.getDateTimeSlot().getDateOfLesson().toLocalTime());
         LocalDate updatedStartDate = editLessonDescriptor.getStartDate()
                 .orElse(toEdit.getDateTimeSlot().getDateOfLesson().toLocalDate());
-        Integer durationHours = editLessonDescriptor.getDurationHours()
-                .orElse(toEdit.getDateTimeSlot().getHours());
-        Integer durationMinutes = editLessonDescriptor.getDurationMinutes()
-                .orElse(toEdit.getDateTimeSlot().getMinutes());
+        Integer durationHours;
+        Integer durationMinutes;
+        if (editLessonDescriptor.getDurationHours().isPresent()
+                || editLessonDescriptor.getDurationMinutes().isPresent()) {
+            durationHours = editLessonDescriptor.getDurationHours().orElse(0);
+            durationMinutes = editLessonDescriptor.getDurationMinutes().orElse(0);
+        } else {
+            durationHours = toEdit.getDateTimeSlot().getHours();
+            durationMinutes = toEdit.getDateTimeSlot().getMinutes();
+        }
         DateTimeSlot updatedDateTimeSlot = new DateTimeSlot(updatedStartDate.atTime(updatedStartTime),
                 durationHours, durationMinutes);
 

--- a/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
@@ -1,0 +1,172 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION_HOURS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION_MINUTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.lesson.DateTimeSlot;
+import seedu.address.model.lesson.Lesson;
+import seedu.address.model.lesson.LessonAddress;
+import seedu.address.model.lesson.LessonName;
+import seedu.address.model.lesson.RecurringLesson;
+import seedu.address.model.lesson.Subject;
+
+public class EditLessonCommand extends Command {
+    public static final String COMMAND_WORD = "editlesson";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a lesson to the schedule"
+            + "\n"
+            + "Parameters: "
+            + PREFIX_LESSON + " LESSON_ID "
+            + PREFIX_LESSON_NAME + " NAME "
+            + PREFIX_SUBJECT + " SUBJECT "
+            + PREFIX_LESSON_ADDRESS + " ADDRESS "
+            + "\n     "
+            + PREFIX_DATE + " DATE "
+            + PREFIX_START_TIME + " START_TIME "
+            + "\n     "
+            + PREFIX_DURATION_HOURS + " DURATION IN HOURS "
+            + PREFIX_DURATION_MINUTES + " DURATION IN MINUTES "
+            + "\n     "
+            + "[EXAMPLE]: "
+            + "\n     "
+            + COMMAND_WORD + " "
+            + PREFIX_LESSON + " 2 "
+            + PREFIX_DATE + " 19-12-2022 "
+            + PREFIX_START_TIME + " 18:00 "
+            + PREFIX_DURATION_HOURS + " 2 "
+            + PREFIX_DURATION_MINUTES + " 15 "
+            + "\nNote: You cannot change recurring lessons to be temporary and vice-versa.";
+
+    public static final String MESSAGE_SUCCESS = "%1$s successfully edited!";
+    public static final String MESSAGE_CONFLICTING_LESSON = "Editing the time/date of this lesson conflicts "
+            + "with an existing lesson in the schedule";
+
+    private final Index lessonId;
+    private final EditLessonDescriptor editLessonDescriptor;
+    public EditLessonCommand(Index lessonId, EditLessonDescriptor editLessonDescriptor) {
+        requireAllNonNull(lessonId, editLessonDescriptor);
+        this.lessonId = lessonId;
+        this.editLessonDescriptor = editLessonDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Lesson> lastShownList = model.getFilteredLessonList();
+        if (lastShownList.size() < lessonId.getOneBased()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX);
+        }
+        Lesson lessonToEdit = lastShownList.get(lessonId.getZeroBased());
+        Lesson editedLesson = createEditedLesson(lessonToEdit, editLessonDescriptor);
+        return null;
+    }
+
+    private Lesson createEditedLesson(Lesson toEdit, EditLessonDescriptor editLessonDescriptor) {
+        requireAllNonNull(toEdit, editLessonDescriptor);
+        LessonName updatedName = editLessonDescriptor.getName().orElse(toEdit.getName());
+        Subject updatedSubject = editLessonDescriptor.getSubject().orElse(toEdit.getSubject());
+        LessonAddress updatedAddress = editLessonDescriptor.getAddress().orElse(toEdit.getLessonAddress());
+        LocalTime updatedStartTime = editLessonDescriptor.getStartTime()
+                .orElse(toEdit.getDateTimeSlot().getDateOfLesson().toLocalTime());
+        LocalDate updatedStartDate = editLessonDescriptor.getStartDate()
+                .orElse(toEdit.getDateTimeSlot().getDateOfLesson().toLocalDate());
+        Integer durationHours = editLessonDescriptor.getDurationHours()
+                .orElse(toEdit.getDateTimeSlot().getHours());
+        Integer durationMinutes = editLessonDescriptor.getDurationMinutes()
+                .orElse(toEdit.getDateTimeSlot().getMinutes());
+        DateTimeSlot updatedDTS = new DateTimeSlot(updatedStartDate.atTime(updatedStartTime),
+                durationHours, durationMinutes);
+
+        return toEdit instanceof RecurringLesson
+                ? Lesson.makeRecurringLesson(updatedName, updatedSubject,
+                updatedAddress, updatedDTS, toEdit.getEnrolledStudents())
+                : Lesson.makeTemporaryLesson(updatedName, updatedSubject,
+                updatedAddress, updatedDTS, toEdit.getEnrolledStudents());
+    }
+
+    public static class EditLessonDescriptor {
+        private LessonName name;
+        private Subject subject;
+        private LessonAddress address;
+        private LocalDate startDate;
+        private LocalTime startTime;
+        private Integer durationHours;
+        private Integer durationMinutes;
+
+        public EditLessonDescriptor () {}
+
+        public void setName(LessonName name) {
+            this.name = name;
+        }
+
+        public void setSubject(Subject subject) {
+            this.subject = subject;
+        }
+
+        public void setAddress(LessonAddress address) {
+            this.address = address;
+        }
+
+        public void setStartDate(LocalDate startDate) {
+            this.startDate = startDate;
+        }
+
+        public void setStartTime(LocalTime startTime) {
+            this.startTime = startTime;
+        }
+
+        public void setDurationHours(Integer durationHours) {
+            this.durationHours = durationHours;
+        }
+
+        public void setDurationMinutes(Integer durationMinutes) {
+            this.durationMinutes = durationMinutes;
+        }
+
+        public Optional<LessonName> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public Optional<Subject> getSubject() {
+            return Optional.ofNullable(subject);
+        }
+
+        public Optional<LessonAddress> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        public Optional<LocalDate> getStartDate() {
+            return Optional.ofNullable(startDate);
+        }
+
+        public Optional<LocalTime> getStartTime() {
+            return Optional.ofNullable(startTime);
+        }
+
+        public Optional<Integer> getDurationHours() {
+            return Optional.ofNullable(durationHours);
+        }
+
+        public Optional<Integer> getDurationMinutes() {
+            return Optional.ofNullable(durationMinutes);
+        }
+
+
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLessonCommandParser.java
@@ -22,7 +22,6 @@ import seedu.address.model.lesson.Subject;
  * Parses input arguments and creates a new AddStudentCommand object
  */
 public class AddLessonCommandParser implements Parser<AddLessonCommand> {
-    public static final String INVALID_DURATION_MESSAGE = "Duration of lesson cannot be zero.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddStudentCommand
@@ -50,7 +49,8 @@ public class AddLessonCommandParser implements Parser<AddLessonCommand> {
         Integer durationMinutes = hasDurationMinutesField(argMultimap)
                 ? ParserUtil.parseDurationMinutes(argMultimap.getValue(PREFIX_DURATION_MINUTES).get())
                 : 0;
-        checkDurationIsValid(durationHours, durationMinutes);
+
+        ParserUtil.checkDurationIsValid(durationHours, durationMinutes);
 
         DateTimeSlot dateTimeSlot = ParserUtil.parseDateTimeSlot(
                 argMultimap.getValue(PREFIX_DATE).get(),
@@ -87,15 +87,5 @@ public class AddLessonCommandParser implements Parser<AddLessonCommand> {
         return !argumentMultimap.getValue(PREFIX_DURATION_MINUTES).isEmpty();
     }
 
-    /**
-     * Checks that the lesson has does not have a total duration of zero minutes.
-     */
-    private static void checkDurationIsValid(int hours, int minutes) throws ParseException {
-        boolean isValidHoursAndMinutes = ((hours > 0 && minutes >= 0 && minutes <= 60)
-                || (hours == 0 && minutes > 0 && minutes <= 60));
 
-        if (!isValidHoursAndMinutes) {
-            throw new ParseException(INVALID_DURATION_MESSAGE);
-        }
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
@@ -19,30 +19,8 @@ import java.util.Optional;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditLessonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.lesson.LessonAddress;
-import seedu.address.model.lesson.LessonName;
-import seedu.address.model.lesson.Subject;
 
 public class EditLessonCommandParser implements Parser<EditLessonCommand> {
-
-    private Optional<LessonName> setLessonName(ArgumentMultimap argMultimap, EditLessonDescriptor e) throws ParseException {
-        return argMultimap.getValue(PREFIX_LESSON_NAME).isEmpty()
-                ? Optional.empty()
-                : Optional.of(ParserUtil.parseLessonName(argMultimap.getValue(PREFIX_LESSON_NAME).get()));
-    }
-
-    private Optional<Subject> getSubject(ArgumentMultimap argMultimap) throws ParseException {
-        return argMultimap.getValue(PREFIX_SUBJECT).isEmpty()
-                ? Optional.empty()
-                : Optional.of(ParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT).get()));
-
-    }
-
-    private Optional<LessonAddress> getLessonAddress(ArgumentMultimap argMultimap) throws ParseException {
-        return argMultimap.getValue(PREFIX_LESSON_ADDRESS).isEmpty()
-                ? Optional.empty()
-                : Optional.of(ParserUtil.parseLessonAddress(argMultimap.getValue(PREFIX_LESSON_ADDRESS).get()));
-    }
 
     private Optional<Integer> getDurationHours(ArgumentMultimap argMultimap) throws ParseException {
         return argMultimap.getValue(PREFIX_DURATION_HOURS).isEmpty()
@@ -56,54 +34,44 @@ public class EditLessonCommandParser implements Parser<EditLessonCommand> {
                 : Optional.of(ParserUtil.parseDurationMinutes(argMultimap.getValue(PREFIX_DURATION_MINUTES).get()));
     }
 
-    private Optional<LocalDate> getDate(ArgumentMultimap argMultimap) throws ParseException {
-        return argMultimap.getValue(PREFIX_DATE).isEmpty()
-                ? Optional.empty()
-                : Optional.of(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
-    }
-
-    private Optional<LocalTime> getTime(ArgumentMultimap argMultimap) throws ParseException {
-        return argMultimap.getValue(PREFIX_START_TIME).isEmpty()
-                ? Optional.empty()
-                : Optional.of(ParserUtil.parseStartTime(argMultimap.getValue(PREFIX_START_TIME).get()));
-    }
-
     @Override
     public EditLessonCommand parse(String userInput) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_LESSON, PREFIX_LESSON_NAME,
                 PREFIX_SUBJECT, PREFIX_LESSON_ADDRESS, PREFIX_DATE, PREFIX_START_TIME,
                 PREFIX_DURATION_HOURS, PREFIX_DURATION_MINUTES);
-        if (CheckPrefixes.arePrefixesAbsent(argMultimap, PREFIX_LESSON) || argMultimap.getPreamble().isEmpty()) {
+        if (argMultimap.getValue(PREFIX_LESSON).isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
         Index lessonId = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_LESSON).get());
         EditLessonDescriptor editLessonDescriptor = new EditLessonDescriptor();
-        if (!argMultimap.getValue(PREFIX_LESSON_NAME).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_LESSON_NAME).isPresent()) {
             editLessonDescriptor.setName(ParserUtil.parseLessonName(argMultimap.getValue(PREFIX_LESSON_NAME).get()));
         }
-        if (!argMultimap.getValue(PREFIX_SUBJECT).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_SUBJECT).isPresent()) {
             editLessonDescriptor.setSubject(ParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT).get()));
         }
-        if (!argMultimap.getValue(PREFIX_LESSON_ADDRESS).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_LESSON_ADDRESS).isPresent()) {
             editLessonDescriptor.setAddress(
                     ParserUtil.parseLessonAddress(argMultimap.getValue(PREFIX_LESSON_ADDRESS).get()));
         }
-        ParserUtil.checkDurationIsValid(
-                getDurationHours(argMultimap).orElse(0), getDurationMinutes(argMultimap).orElse(0));
 
-        if (!argMultimap.getValue(PREFIX_DURATION_HOURS).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_DURATION_HOURS).isPresent()) {
+            ParserUtil.checkDurationIsValid(
+                    getDurationHours(argMultimap).orElse(0), getDurationMinutes(argMultimap).orElse(0));
             editLessonDescriptor.setDurationHours(
                     ParserUtil.parseDurationHours(argMultimap.getValue(PREFIX_DURATION_HOURS).get()));
         }
-        if (!argMultimap.getValue(PREFIX_DURATION_MINUTES).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_DURATION_MINUTES).isPresent()) {
+            ParserUtil.checkDurationIsValid(
+                    getDurationHours(argMultimap).orElse(0), getDurationMinutes(argMultimap).orElse(0));
             editLessonDescriptor.setDurationMinutes(
                     ParserUtil.parseDurationMinutes(argMultimap.getValue(PREFIX_DURATION_MINUTES).get()));
         }
-        if (!argMultimap.getValue(PREFIX_DATE).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
             editLessonDescriptor.setStartDate(
                     ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
         }
-        if (!argMultimap.getValue(PREFIX_START_TIME).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_START_TIME).isPresent()) {
             editLessonDescriptor.setStartTime(
                     ParserUtil.parseStartTime(argMultimap.getValue(PREFIX_START_TIME).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
@@ -12,8 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.Optional;
 
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
@@ -1,0 +1,113 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.EditLessonCommand.EditLessonDescriptor;
+import static seedu.address.logic.commands.EditLessonCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION_HOURS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION_MINUTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditLessonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.lesson.LessonAddress;
+import seedu.address.model.lesson.LessonName;
+import seedu.address.model.lesson.Subject;
+
+public class EditLessonCommandParser implements Parser<EditLessonCommand> {
+
+    private Optional<LessonName> setLessonName(ArgumentMultimap argMultimap, EditLessonDescriptor e) throws ParseException {
+        return argMultimap.getValue(PREFIX_LESSON_NAME).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseLessonName(argMultimap.getValue(PREFIX_LESSON_NAME).get()));
+    }
+
+    private Optional<Subject> getSubject(ArgumentMultimap argMultimap) throws ParseException {
+        return argMultimap.getValue(PREFIX_SUBJECT).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT).get()));
+
+    }
+
+    private Optional<LessonAddress> getLessonAddress(ArgumentMultimap argMultimap) throws ParseException {
+        return argMultimap.getValue(PREFIX_LESSON_ADDRESS).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseLessonAddress(argMultimap.getValue(PREFIX_LESSON_ADDRESS).get()));
+    }
+
+    private Optional<Integer> getDurationHours(ArgumentMultimap argMultimap) throws ParseException {
+        return argMultimap.getValue(PREFIX_DURATION_HOURS).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseDurationHours(argMultimap.getValue(PREFIX_DURATION_HOURS).get()));
+    }
+
+    private Optional<Integer> getDurationMinutes(ArgumentMultimap argMultimap) throws ParseException {
+        return argMultimap.getValue(PREFIX_DURATION_MINUTES).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseDurationMinutes(argMultimap.getValue(PREFIX_DURATION_MINUTES).get()));
+    }
+
+    private Optional<LocalDate> getDate(ArgumentMultimap argMultimap) throws ParseException {
+        return argMultimap.getValue(PREFIX_DATE).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
+    }
+
+    private Optional<LocalTime> getTime(ArgumentMultimap argMultimap) throws ParseException {
+        return argMultimap.getValue(PREFIX_START_TIME).isEmpty()
+                ? Optional.empty()
+                : Optional.of(ParserUtil.parseStartTime(argMultimap.getValue(PREFIX_START_TIME).get()));
+    }
+
+    @Override
+    public EditLessonCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_LESSON, PREFIX_LESSON_NAME,
+                PREFIX_SUBJECT, PREFIX_LESSON_ADDRESS, PREFIX_DATE, PREFIX_START_TIME,
+                PREFIX_DURATION_HOURS, PREFIX_DURATION_MINUTES);
+        if (CheckPrefixes.arePrefixesAbsent(argMultimap, PREFIX_LESSON) || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        }
+        Index lessonId = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_LESSON).get());
+        EditLessonDescriptor editLessonDescriptor = new EditLessonDescriptor();
+        if (!argMultimap.getValue(PREFIX_LESSON_NAME).isEmpty()) {
+            editLessonDescriptor.setName(ParserUtil.parseLessonName(argMultimap.getValue(PREFIX_LESSON_NAME).get()));
+        }
+        if (!argMultimap.getValue(PREFIX_SUBJECT).isEmpty()) {
+            editLessonDescriptor.setSubject(ParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT).get()));
+        }
+        if (!argMultimap.getValue(PREFIX_LESSON_ADDRESS).isEmpty()) {
+            editLessonDescriptor.setAddress(
+                    ParserUtil.parseLessonAddress(argMultimap.getValue(PREFIX_LESSON_ADDRESS).get()));
+        }
+        ParserUtil.checkDurationIsValid(
+                getDurationHours(argMultimap).orElse(0), getDurationMinutes(argMultimap).orElse(0));
+
+        if (!argMultimap.getValue(PREFIX_DURATION_HOURS).isEmpty()) {
+            editLessonDescriptor.setDurationHours(
+                    ParserUtil.parseDurationHours(argMultimap.getValue(PREFIX_DURATION_HOURS).get()));
+        }
+        if (!argMultimap.getValue(PREFIX_DURATION_MINUTES).isEmpty()) {
+            editLessonDescriptor.setDurationMinutes(
+                    ParserUtil.parseDurationMinutes(argMultimap.getValue(PREFIX_DURATION_MINUTES).get()));
+        }
+        if (!argMultimap.getValue(PREFIX_DATE).isEmpty()) {
+            editLessonDescriptor.setStartDate(
+                    ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
+        }
+        if (!argMultimap.getValue(PREFIX_START_TIME).isEmpty()) {
+            editLessonDescriptor.setStartTime(
+                    ParserUtil.parseStartTime(argMultimap.getValue(PREFIX_START_TIME).get()));
+        }
+
+        return new EditLessonCommand(lessonId, editLessonDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditLessonCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.commands.EditLessonCommand.MESSAGE_USAGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION_HOURS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION_MINUTES;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
@@ -34,13 +33,18 @@ public class EditLessonCommandParser implements Parser<EditLessonCommand> {
 
     @Override
     public EditLessonCommand parse(String userInput) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_LESSON, PREFIX_LESSON_NAME,
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_LESSON_NAME,
                 PREFIX_SUBJECT, PREFIX_LESSON_ADDRESS, PREFIX_DATE, PREFIX_START_TIME,
                 PREFIX_DURATION_HOURS, PREFIX_DURATION_MINUTES);
-        if (argMultimap.getValue(PREFIX_LESSON).isEmpty() || !argMultimap.getPreamble().isEmpty()) {
+
+        Index lessonId;
+
+        try {
+            lessonId = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
-        Index lessonId = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_LESSON).get());
+
         EditLessonDescriptor editLessonDescriptor = new EditLessonDescriptor();
         if (argMultimap.getValue(PREFIX_LESSON_NAME).isPresent()) {
             editLessonDescriptor.setName(ParserUtil.parseLessonName(argMultimap.getValue(PREFIX_LESSON_NAME).get()));
@@ -55,13 +59,13 @@ public class EditLessonCommandParser implements Parser<EditLessonCommand> {
 
         if (argMultimap.getValue(PREFIX_DURATION_HOURS).isPresent()) {
             ParserUtil.checkDurationIsValid(
-                    getDurationHours(argMultimap).orElse(0), getDurationMinutes(argMultimap).orElse(0));
+                    getDurationHours(argMultimap).get(), 0);
             editLessonDescriptor.setDurationHours(
                     ParserUtil.parseDurationHours(argMultimap.getValue(PREFIX_DURATION_HOURS).get()));
         }
         if (argMultimap.getValue(PREFIX_DURATION_MINUTES).isPresent()) {
             ParserUtil.checkDurationIsValid(
-                    getDurationHours(argMultimap).orElse(0), getDurationMinutes(argMultimap).orElse(0));
+                    0, getDurationMinutes(argMultimap).get());
             editLessonDescriptor.setDurationMinutes(
                     ParserUtil.parseDurationMinutes(argMultimap.getValue(PREFIX_DURATION_MINUTES).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,22 +4,17 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
-
-import javax.swing.text.html.Option;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.lesson.DateTimeSlot;
-import seedu.address.model.lesson.Lesson;
 import seedu.address.model.lesson.LessonAddress;
 import seedu.address.model.lesson.LessonName;
 import seedu.address.model.lesson.Subject;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,16 +5,21 @@ import static java.util.Objects.requireNonNull;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+
+import javax.swing.text.html.Option;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.lesson.DateTimeSlot;
+import seedu.address.model.lesson.Lesson;
 import seedu.address.model.lesson.LessonAddress;
 import seedu.address.model.lesson.LessonName;
 import seedu.address.model.lesson.Subject;
@@ -33,6 +38,8 @@ public class ParserUtil {
     public static final String INVALID_DATE_FORMAT_MESSAGE = "Invalid date format! Date must be in DD-MM-YYYY\n"
             + "[EXAMPLE]: to specify that a lesson is on 25th March 2022, include the following\n"
             + "-d 25-03-2022";
+
+    public static final String INVALID_DURATION_MESSAGE = "Duration of lesson cannot be zero.";
 
     public static final String INVALID_HOURS_FORMAT_MESSAGE = "Invalid duration in hours format! "
             + "Hours must be a non-negative integer.\n"
@@ -200,6 +207,18 @@ public class ParserUtil {
     }
 
     /**
+     * Checks that the lesson has does not have a total duration of zero minutes.
+     */
+    public static void checkDurationIsValid(int hours, int minutes) throws ParseException {
+        boolean isValidHoursAndMinutes = ((hours > 0 && minutes >= 0 && minutes <= 60)
+                || (hours == 0 && minutes > 0 && minutes <= 60));
+
+        if (!isValidHoursAndMinutes) {
+            throw new ParseException(INVALID_DURATION_MESSAGE);
+        }
+    }
+
+    /**
      * Parses a {@code String dateOfLesson}, a {@code startTime}, a {@code duration hour-field}
      * and a {@code duration minute-field} into a {@code DateTimeSlot}
      *
@@ -209,22 +228,9 @@ public class ParserUtil {
     public static DateTimeSlot parseDateTimeSlot(String dateOfLesson, String startTime,
                                                  int durationHours, int durationMinutes) throws ParseException {
         LocalDate lessonDate = parseDate(dateOfLesson);
-        String lessonStartTime = parseStartTime(startTime);
+        LocalTime lessonStartTime = parseStartTime(startTime);
 
-        String[] hourAndMinuteOfStartTime = startTime.split(":");
-        Integer hour;
-        Integer minute;
-        LocalDateTime lessonDateTime;
-
-        try {
-            hour = Integer.parseInt(hourAndMinuteOfStartTime[0]);
-            minute = Integer.parseInt(hourAndMinuteOfStartTime[1]);
-            lessonDateTime = lessonDate.atTime(hour, minute);
-        } catch (NumberFormatException | DateTimeException exception) {
-            throw new ParseException(String.format("Invalid lesson start time: %s", startTime));
-        }
-
-        return new DateTimeSlot(lessonDateTime, durationHours, durationMinutes);
+        return new DateTimeSlot(lessonDate.atTime(lessonStartTime), durationHours, durationMinutes);
     }
 
     /**
@@ -256,15 +262,20 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code dateOfLesson} is invalid.
      */
-    public static String parseStartTime(String startTime) throws ParseException {
+    public static LocalTime parseStartTime(String startTime) throws ParseException {
         requireNonNull(startTime);
         String trimmedStartTimeString = startTime.trim();
-
         if (!DateTimeSlot.isValidStartTime(trimmedStartTimeString)) {
             throw new ParseException(INVALID_START_TIME_MESSAGE);
         }
+        String[] hourAndMinuteOfStartTime = trimmedStartTimeString.split(":");
+        try {
+            return LocalTime.of(Integer.parseInt(hourAndMinuteOfStartTime[0]),
+                    Integer.parseInt(hourAndMinuteOfStartTime[1]));
+        } catch (NumberFormatException | DateTimeException exception) {
+            throw new ParseException(String.format("Invalid lesson start time: %s", startTime));
+        }
 
-        return trimmedStartTimeString;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
+++ b/src/main/java/seedu/address/logic/parser/TeachWhatParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteLessonCommand;
 import seedu.address.logic.commands.DeleteStudentCommand;
+import seedu.address.logic.commands.EditLessonCommand;
 import seedu.address.logic.commands.EditStudentCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindLessonCommand;
@@ -100,6 +101,8 @@ public class TeachWhatParser {
         case EditStudentCommand.COMMAND_WORD:
             return new EditStudentCommandParser().parse(arguments);
 
+        case EditLessonCommand.COMMAND_WORD:
+            return new EditLessonCommandParser().parse(arguments);
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/model/lesson/DateTimeSlot.java
+++ b/src/main/java/seedu/address/model/lesson/DateTimeSlot.java
@@ -262,7 +262,8 @@ public class DateTimeSlot {
 
         DateTimeSlot otherDateTimeSlot = (DateTimeSlot) other;
         return this.dateOfLesson.equals(otherDateTimeSlot.dateOfLesson)
-                && this.hours == (otherDateTimeSlot.hours);
+                && this.hours == (otherDateTimeSlot.hours)
+                && this.minutes == otherDateTimeSlot.minutes;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLessonCommandParserTest.java
@@ -20,11 +20,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_SUBJECT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.INVALID_DATE_FORMAT_MESSAGE;
+import static seedu.address.logic.parser.ParserUtil.INVALID_DURATION_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.INVALID_START_TIME_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.MINUTES_GREATER_THAN_59_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.NEGATIVE_HOURS_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.NEGATIVE_MINUTES_MESSAGE;
-import static seedu.address.logic.parser.ParserUtil.INVALID_DURATION_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/AddLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLessonCommandParserTest.java
@@ -17,7 +17,6 @@ import static seedu.address.logic.commands.CommandTestUtil.LESSON_SUBJECT_DESC_B
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_ADDRESS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_SUBJECT;
-import static seedu.address.logic.parser.AddLessonCommandParser.INVALID_DURATION_MESSAGE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.INVALID_DATE_FORMAT_MESSAGE;
@@ -25,6 +24,7 @@ import static seedu.address.logic.parser.ParserUtil.INVALID_START_TIME_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.MINUTES_GREATER_THAN_59_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.NEGATIVE_HOURS_MESSAGE;
 import static seedu.address.logic.parser.ParserUtil.NEGATIVE_MINUTES_MESSAGE;
+import static seedu.address.logic.parser.ParserUtil.INVALID_DURATION_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Fixes #114.

The command allows users to edit details of the lessons but do not allow editing of the lesson's type. This means that if a lesson is a temporary lesson, it cannot be edited to become a recurring lesson.