### PR TITLE
Make lesson address and subject fields optional

### DIFF
--- a/src/main/java/seedu/address/model/lesson/LessonAddress.java
+++ b/src/main/java/seedu/address/model/lesson/LessonAddress.java
@@ -16,6 +16,8 @@ public class LessonAddress {
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
+    public static final LessonAddress EMPTY_ADDRESS = new LessonAddress();
+
     public final String value;
 
     /**
@@ -27,6 +29,13 @@ public class LessonAddress {
         requireNonNull(address);
         checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
         value = address;
+    }
+
+    /**
+     * Constructs an empty {@code Address}.
+     */
+    public LessonAddress() {
+        value = "NO ADDRESS ASSIGNED";
     }
 
     /**

--- a/src/main/java/seedu/address/model/lesson/Subject.java
+++ b/src/main/java/seedu/address/model/lesson/Subject.java
@@ -8,27 +8,35 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidSubject(String)}
  */
 public class Subject {
-
     public static final String MESSAGE_CONSTRAINTS =
             "Subject should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
+     * The first character of the subject must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public static final Subject EMPTY_SUBJECT = new Subject();
 
     public final String subjectName;
 
     /**
-     * Constructs a {@code LessonName}.
+     * Constructs a {@code Subject}.
      *
-     * @param name A valid name.
+     * @param name A valid subject name.
      */
     public Subject(String name) {
         requireNonNull(name);
         checkArgument(isValidSubject(name), MESSAGE_CONSTRAINTS);
         subjectName = name;
+    }
+
+    /**
+     * Constructs an empty {@code Subject}
+     */
+    public Subject() {
+        subjectName = "NO SUBJECT ASSIGNED";
     }
 
     /**


### PR DESCRIPTION
This pull-request makes the address and subject arguments optional in the `addlesson` command to shorten the overall command.

If no subject is specified
- a default value "NO SUBJECT ASSIGNED" is given.

If no address is specified
- a default value "NO ADDRESS ASSIGNED" is given.

It also fixes a bug where subject names containing spaces are rejected.