### PR TITLE
InfoPanel Bugfix

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -41,7 +41,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 3, 0, false);
+    public static final Version VERSION = new Version(1, 3, 1, false);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
     private static MainApp mainInstance;

--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -81,7 +81,7 @@ public class AddLessonCommand extends Command {
         }
 
         model.setSelectedLesson(toAdd);
-        return new CommandResult(MESSAGE_SUCCESS, true, InfoPanelTypes.LESSON, ViewTab.LESSON);
+        return new CommandResult(MESSAGE_SUCCESS, InfoPanelTypes.LESSON, ViewTab.LESSON);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
@@ -60,7 +60,7 @@ public class AddStudentCommand extends Command {
 
         model.addStudent(toAdd);
         model.setSelectedStudent(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), InfoPanelTypes.STUDENT, ViewTab.STUDENT);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -59,9 +59,8 @@ public class AssignCommand extends Command {
         }
         model.setSelectedLesson(lesson);
         model.updateAssignment(student, lesson);
-        return new CommandResult(
-                String.format(MESSAGE_SUCCESS, student.getName(), lesson.getName()),
-                true, InfoPanelTypes.LESSON, ViewTab.LESSON);
+        String commandResultMessage = String.format(MESSAGE_SUCCESS, student.getName(), lesson.getName());
+        return new CommandResult(commandResultMessage, InfoPanelTypes.LESSON, ViewTab.LESSON);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -24,7 +24,7 @@ public class ClearCommand extends Command {
         requireNonNull(model);
         model.setLessonBook(new LessonBook());
         model.setStudentBook(new StudentBook());
-        return new CommandResult(MESSAGE_SUCCESS, true, InfoPanelTypes.EMPTY, ViewTab.NONE);
+        return new CommandResult(MESSAGE_SUCCESS, InfoPanelTypes.EMPTY);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -50,21 +50,35 @@ public class CommandResult {
 
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and with the intention of updating the UI with a new {@code InfoPanel}
+     * and with the intention of updating the UI with a new {@code InfoPanel} and {@code ViewTab}
      *
      * @param feedbackToUser Feedback given to user from the command.
-     * @param updateInfoPanel Boolean indicating if the {@code InfoPanel} of the UI is updated.
      * @param infoPanelType {@code InfoPanelTypes} value representing the type of {@code InfoPanel} that is updated.
      * @param viewTab {@code viewTab} value representing the type of {@code ViewTab} that will be switched.
      */
-    public CommandResult(String feedbackToUser, boolean updateInfoPanel,
-                         InfoPanelTypes infoPanelType, ViewTab viewTab) {
+    public CommandResult(String feedbackToUser, InfoPanelTypes infoPanelType, ViewTab viewTab) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = false;
         this.exit = false;
-        this.updateInfoPanel = updateInfoPanel;
+        this.updateInfoPanel = true;
         this.infoPanelType = infoPanelType;
         this.viewTab = viewTab;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * and with the intention of updating the UI with a new {@code InfoPanel}.
+     *
+     * @param feedbackToUser Feedback given to user from the command.
+     * @param infoPanelType {@code InfoPanelTypes} value representing the type of {@code InfoPanel} that is updated.
+     */
+    public CommandResult(String feedbackToUser, InfoPanelTypes infoPanelType) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = false;
+        this.exit = false;
+        this.updateInfoPanel = true;
+        this.infoPanelType = infoPanelType;
+        this.viewTab = ViewTab.NONE;
     }
 
     /**
@@ -76,7 +90,7 @@ public class CommandResult {
         this.exit = false;
         this.viewTab = viewTab;
         this.updateInfoPanel = false;
-        this.infoPanelType = null;
+        this.infoPanelType = InfoPanelTypes.NONE;
     }
 
     public String getFeedbackToUser() {

--- a/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.misc.InfoPanelTypes;
 import seedu.address.model.Model;
 import seedu.address.model.lesson.Lesson;
 
@@ -43,7 +44,12 @@ public class DeleteLessonCommand extends Command {
 
         Lesson lessonToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteLesson(lessonToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_LESSON_SUCCESS, lessonToDelete));
+        boolean shouldClearInfoPanel = model.shouldClearLessonInfoPanelOnDelete(lessonToDelete);
+        String commandResultMessage = String.format(MESSAGE_DELETE_LESSON_SUCCESS, lessonToDelete);
+        if (shouldClearInfoPanel) {
+            return new CommandResult(commandResultMessage, true, InfoPanelTypes.EMPTY, ViewTab.NONE);
+        }
+        return new CommandResult(commandResultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
@@ -47,7 +47,7 @@ public class DeleteLessonCommand extends Command {
         boolean shouldClearInfoPanel = model.shouldClearLessonInfoPanelOnDelete(lessonToDelete);
         String commandResultMessage = String.format(MESSAGE_DELETE_LESSON_SUCCESS, lessonToDelete);
         if (shouldClearInfoPanel) {
-            return new CommandResult(commandResultMessage, true, InfoPanelTypes.EMPTY, ViewTab.NONE);
+            return new CommandResult(commandResultMessage, InfoPanelTypes.EMPTY);
         }
         return new CommandResult(commandResultMessage);
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
@@ -47,7 +47,7 @@ public class DeleteStudentCommand extends Command {
         boolean shouldClearInfoPanel = model.shouldClearStudentInfoPanelOnDelete(studentToDelete);
         String commandResultMessage = String.format(MESSAGE_DELETE_STUDENT_SUCCESS, studentToDelete);
         if (shouldClearInfoPanel) {
-            return new CommandResult(commandResultMessage, true, InfoPanelTypes.EMPTY, ViewTab.NONE);
+            return new CommandResult(commandResultMessage, InfoPanelTypes.EMPTY);
         }
         return new CommandResult(commandResultMessage);
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.misc.InfoPanelTypes;
 import seedu.address.model.Model;
 import seedu.address.model.student.Student;
 
@@ -43,7 +44,12 @@ public class DeleteStudentCommand extends Command {
 
         Student studentToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteStudent(studentToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_STUDENT_SUCCESS, studentToDelete));
+        boolean shouldClearInfoPanel = model.shouldClearStudentInfoPanelOnDelete(studentToDelete);
+        String commandResultMessage = String.format(MESSAGE_DELETE_STUDENT_SUCCESS, studentToDelete);
+        if (shouldClearInfoPanel) {
+            return new CommandResult(commandResultMessage, true, InfoPanelTypes.EMPTY, ViewTab.NONE);
+        }
+        return new CommandResult(commandResultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
@@ -99,8 +99,8 @@ public class EditLessonCommand extends Command {
         model.addLesson(editedLesson);
         model.setSelectedLesson(editedLesson);
         model.updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedLesson.getName()), true,
-                InfoPanelTypes.LESSON, ViewTab.NONE);
+        String commandResultMessage = String.format(MESSAGE_SUCCESS, editedLesson.getName());
+        return new CommandResult(commandResultMessage, InfoPanelTypes.LESSON);
     }
 
     private Lesson createEditedLesson(Lesson toEdit, EditLessonDescriptor editLessonDescriptor) {

--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -86,8 +86,8 @@ public class EditStudentCommand extends Command {
         model.setSelectedStudent(editedStudent);
         model.setStudent(studentToEdit, editedStudent);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-        return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent), true,
-                InfoPanelTypes.STUDENT, ViewTab.STUDENT);
+        String commandResultMessage = String.format(MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);
+        return new CommandResult(commandResultMessage, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -61,8 +61,8 @@ public class UnassignCommand extends Command {
         }
         model.updateUnassignment(student, lesson);
         model.setSelectedStudent(student);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, student.getName(), lesson.getName()),
-                true, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
+        String commandResultMessage = String.format(MESSAGE_SUCCESS, student.getName(), lesson.getName());
+        return new CommandResult(commandResultMessage, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ViewLessonInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewLessonInfoCommand.java
@@ -44,8 +44,8 @@ public class ViewLessonInfoCommand extends Command {
 
         Lesson lessonToSelect = lastShownList.get(targetIndex.getZeroBased());
         model.setSelectedLesson(lessonToSelect);
-        return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, lessonToSelect.getName()),
-                true, InfoPanelTypes.LESSON, ViewTab.LESSON);
+        String commandResultMessage = String.format(MESSAGE_VIEW_SUCCESS, lessonToSelect.getName());
+        return new CommandResult(commandResultMessage, InfoPanelTypes.LESSON, ViewTab.LESSON);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewStudentInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewStudentInfoCommand.java
@@ -43,8 +43,8 @@ public class ViewStudentInfoCommand extends Command {
 
         Student studentToSelect = lastShownList.get(targetIndex.getZeroBased());
         model.setSelectedStudent(studentToSelect);
-        return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, studentToSelect.getName()),
-                true, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
+        String commandResultMessage = String.format(MESSAGE_VIEW_SUCCESS, studentToSelect.getName());
+        return new CommandResult(commandResultMessage, InfoPanelTypes.STUDENT, ViewTab.STUDENT);
     }
 
 

--- a/src/main/java/seedu/address/logic/commands/misc/InfoPanelTypes.java
+++ b/src/main/java/seedu/address/logic/commands/misc/InfoPanelTypes.java
@@ -6,7 +6,8 @@ package seedu.address.logic.commands.misc;
 public enum InfoPanelTypes {
     STUDENT("Student Info Panel"),
     LESSON("Lesson Info Panel"),
-    EMPTY("Empty Info Panel");
+    EMPTY("Clear Info Panel"),
+    NONE("No change to Info Panel");
 
     private final String str;
     InfoPanelTypes(String string) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -172,4 +172,20 @@ public interface Model {
      * Checks if the {@code Index} provided is out of bounds of the {@code filteredLessonList}
      */
     boolean checkLessonListIndex(Index lessonId);
+
+    /**
+     * Checks if the provided {@code Lesson} is the one currently being viewed on the {@code InfoPanel} in
+     * {@code MainWindow}
+     *
+     * @return If InfoPanel should be cleared.
+     */
+    boolean shouldClearLessonInfoPanelOnDelete(Lesson deletedLesson);
+
+    /**
+     * Checks if the provided {@code Student} is the one currently being viewed on the {@code InfoPanel} in
+     * {@code MainWindow}
+     *
+     * @return If InfoPanel should be cleared.
+     */
+    boolean shouldClearStudentInfoPanelOnDelete(Student deletedStudent);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -175,16 +175,18 @@ public interface Model {
 
     /**
      * Checks if the provided {@code Lesson} is the one currently being viewed on the {@code InfoPanel} in
-     * {@code MainWindow}
+     * {@code MainWindow}.
      *
+     * @param deletedLesson Lesson to be deleted.
      * @return If InfoPanel should be cleared.
      */
     boolean shouldClearLessonInfoPanelOnDelete(Lesson deletedLesson);
 
     /**
      * Checks if the provided {@code Student} is the one currently being viewed on the {@code InfoPanel} in
-     * {@code MainWindow}
+     * {@code MainWindow}.
      *
+     * @param deletedStudent Student to be deleted.
      * @return If InfoPanel should be cleared.
      */
     boolean shouldClearStudentInfoPanelOnDelete(Student deletedStudent);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.misc.InfoPanelTypes;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.student.Student;
 
@@ -28,6 +29,7 @@ public class ModelManager implements Model {
     private final FilteredList<Lesson> filteredLessons;
     private Student selectedStudent;
     private Lesson selectedLesson;
+    private InfoPanelTypes currentInfoPanel;
 
     /**
      * Initializes a ModelManager with the given studentBook and userPrefs.
@@ -251,6 +253,7 @@ public class ModelManager implements Model {
 
     public void setSelectedStudent(Student student) {
         selectedStudent = student;
+        currentInfoPanel = InfoPanelTypes.STUDENT;
     }
 
     public Student getSelectedStudent() {
@@ -259,10 +262,22 @@ public class ModelManager implements Model {
 
     public void setSelectedLesson(Lesson lesson) {
         selectedLesson = lesson;
+        currentInfoPanel = InfoPanelTypes.LESSON;
     }
 
     public Lesson getSelectedLesson() {
         return selectedLesson;
     }
 
+    public boolean shouldClearLessonInfoPanelOnDelete(Lesson deletedLesson) {
+        boolean isLessonInfoPanel = currentInfoPanel == InfoPanelTypes.LESSON;
+        boolean isSameLesson = selectedLesson.equals(deletedLesson);
+        return isLessonInfoPanel && isSameLesson;
+    }
+
+    public boolean shouldClearStudentInfoPanelOnDelete(Student deletedStudent) {
+        boolean isStudentInfoPanel = currentInfoPanel == InfoPanelTypes.STUDENT;
+        boolean isSameStudent = selectedStudent.equals(deletedStudent);
+        return isStudentInfoPanel && isSameStudent;
+    }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -269,13 +269,29 @@ public class ModelManager implements Model {
         return selectedLesson;
     }
 
+    /**
+     * Checks if the provided {@code Lesson} is the one currently being viewed on the {@code InfoPanel} in
+     * {@code MainWindow}.
+     *
+     * @param deletedLesson Lesson to be deleted.
+     * @return If InfoPanel should be cleared.
+     */
     public boolean shouldClearLessonInfoPanelOnDelete(Lesson deletedLesson) {
+        requireNonNull(deletedLesson);
         boolean isLessonInfoPanel = currentInfoPanel == InfoPanelTypes.LESSON;
         boolean isSameLesson = deletedLesson.equals(selectedLesson);
         return isLessonInfoPanel && isSameLesson;
     }
 
+    /**
+     * Checks if the provided {@code Student} is the one currently being viewed on the {@code InfoPanel} in
+     * {@code MainWindow}.
+     *
+     * @param deletedStudent Student to be deleted.
+     * @return If InfoPanel should be cleared.
+     */
     public boolean shouldClearStudentInfoPanelOnDelete(Student deletedStudent) {
+        requireNonNull(deletedStudent);
         boolean isStudentInfoPanel = currentInfoPanel == InfoPanelTypes.STUDENT;
         boolean isSameStudent = deletedStudent.equals(selectedStudent);
         return isStudentInfoPanel && isSameStudent;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -271,13 +271,13 @@ public class ModelManager implements Model {
 
     public boolean shouldClearLessonInfoPanelOnDelete(Lesson deletedLesson) {
         boolean isLessonInfoPanel = currentInfoPanel == InfoPanelTypes.LESSON;
-        boolean isSameLesson = selectedLesson.equals(deletedLesson);
+        boolean isSameLesson = deletedLesson.equals(selectedLesson);
         return isLessonInfoPanel && isSameLesson;
     }
 
     public boolean shouldClearStudentInfoPanelOnDelete(Student deletedStudent) {
         boolean isStudentInfoPanel = currentInfoPanel == InfoPanelTypes.STUDENT;
-        boolean isSameStudent = selectedStudent.equals(deletedStudent);
+        boolean isSameStudent = deletedStudent.equals(selectedStudent);
         return isStudentInfoPanel && isSameStudent;
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -203,7 +203,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
-            clearInfoPanel();
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -203,6 +203,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
+            clearInfoPanel();
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStudentCommandTest.java
@@ -223,6 +223,16 @@ public class AddStudentCommandTest {
         }
 
         @Override
+        public boolean shouldClearLessonInfoPanelOnDelete(Lesson deletedLesson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean shouldClearStudentInfoPanelOnDelete(Student deletedStudent) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean checkStudentListIndex(Index studentId) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Whenever a ```student``` or ```lesson``` being viewed on the ```InfoPanel``` is deleted, the ```InfoPanel``` is not cleared.
This PR fixes that by clearing the ```InfoPanel``` on every command execution.