### PR TITLE
Fix wrong error message when index out of bounds is input for `assign…

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,6 +7,10 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_NO_INDEX_OR_PREFIX_PROVIDED = "You either did not provide a valid index or "
+            + "a valid prefix required! "
+            + "\nThe index has to be a non-negative integer lesser than or equal to the size of the list. "
+            + "\n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_INVALID_LESSON_DISPLAYED_INDEX = "The lesson index provided is invalid.";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";

--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -47,10 +47,11 @@ public class AssignCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (model.checkStudentListIndex(studentIndex)) {
-            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "lesson", lessonIndex.getOneBased()));
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "student", studentIndex.getOneBased()));
         }
         if (model.checkLessonListIndex(lessonIndex)) {
-            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "student", studentIndex.getOneBased()));
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "lesson", lessonIndex.getOneBased()));
+
         }
         Lesson lesson = model.getFilteredLessonList().get(lessonIndex.getZeroBased());
         Student student = model.getFilteredStudentList().get(studentIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -48,10 +48,11 @@ public class UnassignCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (model.checkStudentListIndex(studentId)) {
-            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "lesson", lessonId.getOneBased()));
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "student", studentId.getOneBased()));
         }
         if (model.checkLessonListIndex(lessonId)) {
-            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "student", studentId.getOneBased()));
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ID, "lesson", lessonId.getOneBased()));
+
         }
 
         Student student = model.getFilteredStudentList().get(studentId.getZeroBased());

--- a/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NO_INDEX_OR_PREFIX_PROVIDED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT;
 
@@ -22,7 +23,7 @@ public class AssignCommandParser implements Parser<AssignCommand> {
             Index studentIndex = ParserUtil.parseIndex(argMultiMap.getValue(PREFIX_STUDENT).get());
             return new AssignCommand(studentIndex, lessonIndex);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_NO_INDEX_OR_PREFIX_PROVIDED, AssignCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnassignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NO_INDEX_OR_PREFIX_PROVIDED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT;
 
@@ -21,7 +22,7 @@ public class UnassignCommandParser implements Parser<UnassignCommand> {
             Index studentId = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_STUDENT).get());
             return new UnassignCommand(studentId, lessonId);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_NO_INDEX_OR_PREFIX_PROVIDED, UnassignCommand.MESSAGE_USAGE));
         }
     }
 }


### PR DESCRIPTION
…` and `unassign` command


Fixes bugs
* `Assign` and `Unassign` showing wrong error message when given invalid input.
    * e.g. when invalid student index is given, error message showed invalid lesson index and vice-versa
* `Assign` and `Unassign` showing wrong error message when index larger than integer given.
    * e.g. when `assign -s 999999999999 -l 9999999999` is input, the error message shows invalid command format. 

Let's use an error message that tells the user what the input constraints are and how the command should be formatted.