### PR TITLE
Fix bug where `RecurringLesson` conflicts with `TemporaryLesson` that…

### DIFF
--- a/src/main/java/seedu/address/model/lesson/RecurringLesson.java
+++ b/src/main/java/seedu/address/model/lesson/RecurringLesson.java
@@ -41,6 +41,9 @@ public class RecurringLesson extends Lesson {
             return false;
         }
         if (otherLesson instanceof TemporaryLesson) {
+            if (otherLesson.getDateTimeSlot().getDateOfLesson().isBefore(super.getDateTimeSlot().getDateOfLesson())) {
+                return false;
+            }
             LocalDateTime tempDate = LocalDateTime.of(otherLesson.getDateTimeSlot().getDateOfLesson().toLocalDate(),
                     this.getDateTimeSlot().getDateOfLesson().toLocalTime());
             DateTimeSlot temp = new DateTimeSlot(tempDate,


### PR DESCRIPTION
… occurred in the past

Amend `RecurringLesson#isConflictingWith()` to return false if the date of the `otherLesson` if date is before starting date of the  `RecurringLesson`.

